### PR TITLE
Feat: Add Telemetry Generation

### DIFF
--- a/config/config-sample-client-localhost.yaml
+++ b/config/config-sample-client-localhost.yaml
@@ -104,3 +104,8 @@ app:
   # Mandatory.
   httpTimeout: "PT3S"
   httpRetryCount: 2
+  telemetry:
+    enabled: true
+    url: ""
+    batchSize: 100
+    syncInterval: 30 # In minutes

--- a/config/config-sample-client-localhost.yaml
+++ b/config/config-sample-client-localhost.yaml
@@ -105,7 +105,7 @@ app:
   httpTimeout: "PT3S"
   httpRetryCount: 2
   telemetry:
-    enabled: true
+    enabled: false
     url: ""
     batchSize: 100
     syncInterval: 30 # In minutes

--- a/config/config-sample-network-localhost.yaml
+++ b/config/config-sample-network-localhost.yaml
@@ -103,3 +103,8 @@ app:
   # Mandatory.
   httpTimeout: "PT3S"
   httpRetryCount: 2
+  telemetry:
+    enabled: true
+    url: ""
+    batchSize: 100
+    syncInterval: 30 # In minutes

--- a/config/config-sample-network-localhost.yaml
+++ b/config/config-sample-network-localhost.yaml
@@ -104,7 +104,7 @@ app:
   httpTimeout: "PT3S"
   httpRetryCount: 2
   telemetry:
-    enabled: true
+    enabled: false
     url: ""
     batchSize: 100
     syncInterval: 30 # In minutes

--- a/config/config-sample.yaml
+++ b/config/config-sample.yaml
@@ -83,3 +83,8 @@ app:
   # Mandatory.
   httpTimeout: "PT3S"
   httpRetryCount: 2
+  telemetry:
+    enabled: true
+    url: ""
+    batchSize: 100
+    syncInterval: 30 # In minutes

--- a/config/config-sample.yaml
+++ b/config/config-sample.yaml
@@ -84,7 +84,7 @@ app:
   httpTimeout: "PT3S"
   httpRetryCount: 2
   telemetry:
-    enabled: true
+    enabled: false
     url: ""
     batchSize: 100
     syncInterval: 30 # In minutes

--- a/config/new-config-sample.yaml
+++ b/config/new-config-sample.yaml
@@ -84,3 +84,8 @@ app:
   # Mandatory.
   httpTimeout: "PT3S"
   httpRetryCount: 2
+  telemetry:
+    enabled: true
+    url: ""
+    batchSize: 100
+    syncInterval: 30 # In minutes

--- a/config/new-config-sample.yaml
+++ b/config/new-config-sample.yaml
@@ -85,7 +85,7 @@ app:
   httpTimeout: "PT3S"
   httpRetryCount: 2
   telemetry:
-    enabled: true
+    enabled: false
     url: ""
     batchSize: 100
     syncInterval: 30 # In minutes

--- a/config/samples/bap-client.yaml
+++ b/config/samples/bap-client.yaml
@@ -124,3 +124,8 @@ app:
   # Mandatory.
   httpTimeout: "PT3S"
   httpRetryCount: 2
+  telemetry:
+    enabled: true
+    url: ""
+    batchSize: 100
+    syncInterval: 30 # In minutes

--- a/config/samples/bap-client.yaml
+++ b/config/samples/bap-client.yaml
@@ -125,7 +125,7 @@ app:
   httpTimeout: "PT3S"
   httpRetryCount: 2
   telemetry:
-    enabled: true
+    enabled: false
     url: ""
     batchSize: 100
     syncInterval: 30 # In minutes

--- a/config/samples/bap-network.yaml
+++ b/config/samples/bap-network.yaml
@@ -124,3 +124,8 @@ app:
   # Mandatory.
   httpTimeout: "PT3S"
   httpRetryCount: 2
+  telemetry:
+    enabled: true
+    url: ""
+    batchSize: 100
+    syncInterval: 30 # In minutes

--- a/config/samples/bap-network.yaml
+++ b/config/samples/bap-network.yaml
@@ -125,7 +125,7 @@ app:
   httpTimeout: "PT3S"
   httpRetryCount: 2
   telemetry:
-    enabled: true
+    enabled: false
     url: ""
     batchSize: 100
     syncInterval: 30 # In minutes

--- a/config/samples/bpp-client.yaml
+++ b/config/samples/bpp-client.yaml
@@ -122,3 +122,8 @@ app:
   # Mandatory.
   httpTimeout: "PT3S"
   httpRetryCount: 2
+  telemetry:
+    enabled: true
+    url: ""
+    batchSize: 100
+    syncInterval: 30 # In minutes

--- a/config/samples/bpp-client.yaml
+++ b/config/samples/bpp-client.yaml
@@ -123,7 +123,7 @@ app:
   httpTimeout: "PT3S"
   httpRetryCount: 2
   telemetry:
-    enabled: true
+    enabled: false
     url: ""
     batchSize: 100
     syncInterval: 30 # In minutes

--- a/config/samples/bpp-network.yaml
+++ b/config/samples/bpp-network.yaml
@@ -122,3 +122,8 @@ app:
   # Mandatory.
   httpTimeout: "PT3S"
   httpRetryCount: 2
+  telemetry:
+    enabled: true
+    url: ""
+    batchSize: 100
+    syncInterval: 30 # In minutes

--- a/config/samples/bpp-network.yaml
+++ b/config/samples/bpp-network.yaml
@@ -123,7 +123,7 @@ app:
   httpTimeout: "PT3S"
   httpRetryCount: 2
   telemetry:
-    enabled: true
+    enabled: false
     url: ""
     batchSize: 100
     syncInterval: 30 # In minutes

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,12 +11,14 @@
       "dependencies": {
         "amqplib": "^0.10.0",
         "axios": "^0.26.1",
+        "axios-retry": "^4.0.0",
         "config": "^3.3.7",
         "express": "^4.18.1",
         "express-openapi-validator": "^4.13.8",
         "ioredis": "^5.0.6",
         "libsodium-wrappers": "^0.7.9",
         "mongodb": "^4.7.0",
+        "request-ip": "^3.3.0",
         "uuid": "^8.3.2",
         "winston": "^3.7.2",
         "winston-daily-rotate-file": "^4.7.1",
@@ -28,6 +30,7 @@
         "@types/express": "^4.17.13",
         "@types/libsodium-wrappers": "^0.7.9",
         "@types/node": "^17.0.41",
+        "@types/request-ip": "0.0.41",
         "@types/uuid": "^8.3.4",
         "nodemon": "^2.0.16",
         "ts-node": "^10.8.1",
@@ -233,6 +236,15 @@
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
       "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
     },
+    "node_modules/@types/request-ip": {
+      "version": "0.0.41",
+      "resolved": "https://registry.npmjs.org/@types/request-ip/-/request-ip-0.0.41.tgz",
+      "integrity": "sha512-Qzz0PM2nSZej4lsLzzNfADIORZhhxO7PED0fXpg4FjXiHuJ/lMyUg+YFF5q8x9HPZH3Gl6N+NOM8QZjItNgGKg==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/serve-static": {
       "version": "1.13.10",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz",
@@ -396,6 +408,17 @@
       "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
       "dependencies": {
         "follow-redirects": "^1.14.8"
+      }
+    },
+    "node_modules/axios-retry": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-4.0.0.tgz",
+      "integrity": "sha512-F6P4HVGITD/v4z9Lw2mIA24IabTajvpDZmKa6zq/gGwn57wN5j1P3uWrAV0+diqnW6kTM2fTqmWNfgYWGmMuiA==",
+      "dependencies": {
+        "is-retry-allowed": "^2.2.0"
+      },
+      "peerDependencies": {
+        "axios": "0.x || 1.x"
       }
     },
     "node_modules/balanced-match": {
@@ -1247,6 +1270,17 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-retry-allowed": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
+      "integrity": "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
@@ -1767,6 +1801,11 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/request-ip": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/request-ip/-/request-ip-3.3.0.tgz",
+      "integrity": "sha512-cA6Xh6e0fDBBBwH77SLJaJPBmD3nWVAcF9/XAcsrIHdjhFzFiB5aNQFytdjCGPezU3ROwrR11IddKAM08vohxA=="
     },
     "node_modules/requires-port": {
       "version": "1.0.0",
@@ -2521,6 +2560,15 @@
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
       "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
     },
+    "@types/request-ip": {
+      "version": "0.0.41",
+      "resolved": "https://registry.npmjs.org/@types/request-ip/-/request-ip-0.0.41.tgz",
+      "integrity": "sha512-Qzz0PM2nSZej4lsLzzNfADIORZhhxO7PED0fXpg4FjXiHuJ/lMyUg+YFF5q8x9HPZH3Gl6N+NOM8QZjItNgGKg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/serve-static": {
       "version": "1.13.10",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz",
@@ -2664,6 +2712,14 @@
       "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
       "requires": {
         "follow-redirects": "^1.14.8"
+      }
+    },
+    "axios-retry": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-4.0.0.tgz",
+      "integrity": "sha512-F6P4HVGITD/v4z9Lw2mIA24IabTajvpDZmKa6zq/gGwn57wN5j1P3uWrAV0+diqnW6kTM2fTqmWNfgYWGmMuiA==",
+      "requires": {
+        "is-retry-allowed": "^2.2.0"
       }
     },
     "balanced-match": {
@@ -3324,6 +3380,11 @@
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true
     },
+    "is-retry-allowed": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
+      "integrity": "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg=="
+    },
     "is-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
@@ -3721,6 +3782,11 @@
       "requires": {
         "redis-errors": "^1.0.0"
       }
+    },
+    "request-ip": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/request-ip/-/request-ip-3.3.0.tgz",
+      "integrity": "sha512-cA6Xh6e0fDBBBwH77SLJaJPBmD3nWVAcF9/XAcsrIHdjhFzFiB5aNQFytdjCGPezU3ROwrR11IddKAM08vohxA=="
     },
     "requires-port": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "amqplib": "^0.10.0",
     "axios": "^0.26.1",
+    "axios-retry": "^4.0.0",
     "config": "^3.3.7",
     "express": "^4.18.1",
     "express-openapi-validator": "^4.13.8",

--- a/src/controllers/bap.response.controller.ts
+++ b/src/controllers/bap.response.controller.ts
@@ -16,6 +16,8 @@ import { getConfig } from "../utils/config.utils";
 import { ClientConfigType } from "../schemas/configs/client.config.schema";
 import { SyncCache } from "../utils/cache/sync.cache.utils";
 import { responseCallback } from "../utils/callback.utils";
+import { telemetryCache } from "../schemas/cache/telemetry.cache";
+import { createTelemetryEvent, pushTelemetry } from "../utils/telemetry.utils";
 
 export const bapNetworkResponseHandler = async (
   req: Request,
@@ -84,6 +86,11 @@ export const bapNetworkResponseSettler = async (
     const action = ActionUtils.getCorrespondingRequestAction(
       responseBody.context.action
     );
+    // Generate telemetry if enabled
+    if(getConfig().app.telemetry.enabled) {
+      telemetryCache.get("bap_response_settled")?.push(createTelemetryEvent({context: responseBody.context}));
+      await pushTelemetry();
+    }
     switch (getConfig().client.type) {
       case ClientConfigType.synchronous: {
         await SyncCache.getInstance().insertResponse(

--- a/src/controllers/bap.trigger.controller.ts
+++ b/src/controllers/bap.trigger.controller.ts
@@ -22,6 +22,8 @@ import { callNetwork } from "../utils/becknRequester.utils";
 import { BecknResponse } from "../schemas/becknResponse.schema";
 import { SyncCache } from "../utils/cache/sync.cache.utils";
 import { errorCallback } from "../utils/callback.utils";
+import { telemetryCache } from "../schemas/cache/telemetry.cache";
+import { createTelemetryEvent, pushTelemetry } from "../utils/telemetry.utils";
 
 export const bapClientTriggerHandler = async (
   req: Request,
@@ -145,6 +147,11 @@ export const bapClientTriggerSettler = async (
       response.status == 206
     ) {
       // Network Calls Succeeded.
+      // Generate Telemetry if enabled
+      if(getConfig().app.telemetry.enabled) {
+        telemetryCache.get("bap_client_settled")?.push(createTelemetryEvent({context: requestBody.context, data: response}));
+        await pushTelemetry();
+      }
       return;
     }
 

--- a/src/controllers/bpp.response.controller.ts
+++ b/src/controllers/bpp.response.controller.ts
@@ -22,6 +22,8 @@ import { getConfig } from "../utils/config.utils";
 import { ClientConfigType } from "../schemas/configs/client.config.schema";
 import { ActionUtils } from "../utils/actions.utils";
 import { acknowledgeACK } from "../utils/acknowledgement.utils";
+import { telemetryCache } from "../schemas/cache/telemetry.cache";
+import { createTelemetryEvent, pushTelemetry } from "../utils/telemetry.utils";
 
 export const bppClientResponseHandler = async (
   req: Request,
@@ -110,6 +112,11 @@ export const bppClientResponseSettler = async (
       response.status == 206
     ) {
       // Network Calls Succeeded.
+      // Generate Telemetry if enabled
+      if(getConfig().app.telemetry.enabled) {
+          telemetryCache.get("bpp_client_settled")?.push(createTelemetryEvent({context: responseBody.context, data: response}));
+          await pushTelemetry();
+      }
       return;
     }
 

--- a/src/schemas/cache/telemetry.cache.ts
+++ b/src/schemas/cache/telemetry.cache.ts
@@ -1,0 +1,43 @@
+export const telemetryEnvelop: any = {
+    eid: "API",
+    ets: "",
+    ver: "1.0",
+    mid: "",
+    context: {
+        channel: "",
+        domain: "",
+        pdata: {
+            id: "",
+            uri: ""
+        },
+        source: {
+            id: "",
+            type: "",
+            uri: ""
+        },
+        target: {
+            id: "",
+            type: "",
+            uri: ""
+        },
+        cdata: []
+    },
+    data: {
+        url: "",
+        method: "",
+        action: "",
+        transactionid: "",
+        msgid: "",
+        exdata: []
+    }
+}
+
+const telemetryCacheStructure = {
+    last_sync_time: new Date().getTime(),
+    bap_client_settled: [],
+    bap_response_settled: [],
+    bpp_client_settled: [],
+    bpp_request_settled: [],
+}
+
+export const telemetryCache = new Map<string, any>(Object.entries(telemetryCacheStructure));

--- a/src/schemas/configs/app.config.schema.ts
+++ b/src/schemas/configs/app.config.schema.ts
@@ -42,6 +42,13 @@ export const appConfigSchema = z.object({
         return duration.asMilliseconds();
     }),
     httpRetryCount: z.number(),
+    
+    telemetry: z.object({
+        enabled: z.boolean(),
+        url: z.string(),
+        batchSize: z.number(),
+        syncInterval: z.number()
+    }),
 });
 
 export type AppConfigDataType = z.infer<typeof appConfigSchema>;

--- a/src/utils/telemetry.utils.ts
+++ b/src/utils/telemetry.utils.ts
@@ -1,0 +1,99 @@
+import axios from "axios";
+import { telemetryCache, telemetryEnvelop } from "../schemas/cache/telemetry.cache";
+import { getConfig } from "../utils/config.utils";
+import logger from "../utils/logger.utils";
+import axiosRetry from 'axios-retry';
+import { v1 } from "uuid";
+axiosRetry(axios, { retries: 3 });
+
+const constructCdata = (message: any) => {
+    const cdata: any = [];
+    if (message.context.hasOwnProperty('location')) {
+        Object.entries(message.context.location).map(([dataKey, dataValue]: any) => {
+            cdata.push({
+                type: dataKey,
+                value: dataValue.name,
+                valueType: "string"
+            });
+            cdata.push({
+                type: dataKey+"code",
+                value: dataValue.code,
+                valueType: "string"
+            });
+        })
+    }
+    return cdata;
+}
+
+export function createTelemetryEvent(message: any) {
+    let telemetry = { ...telemetryEnvelop };
+    telemetry.ets = Date.now();
+    telemetry.mid = v1();
+    telemetry.context = {
+        channel: getConfig().app.subscriberId,
+        domain: message.context.domain,
+        pdata: {
+            id: getConfig().app.subscriberId,
+            uri: getConfig().app.subscriberUri
+        },
+        source: {
+            id: getConfig().app.subscriberId,
+            type: getConfig().app.mode === "bap" ? "seeker" : "provider",
+            uri: getConfig().app.subscriberUri
+        },
+        target: {
+            id: getConfig().app.mode === "bap" ? message.context.bpp_id : message.context.bap_id,
+            type: getConfig().app.mode === "bap" ? "provider" : "seeker",
+            uri: getConfig().app.mode === "bap" ? message.context.bpp_uri : message.context.bap_uri
+        },
+        cdata: constructCdata(message)
+    };
+    telemetry.data = {
+        url: `/${message.context.action}`,
+        method: "POST",
+        action: message.context.action,
+        transactionid: message.context.transaction_id,
+        msgid: message.context.message_id,
+        exdata: []
+    };
+
+    if(message.hasOwnProperty('data') && message.data.hasOwnProperty('statuscode')) telemetry.data["statuscode"] = message.data.statuscode;
+    return telemetry;
+}
+
+export async function pushTelemetry() {
+    const last_sync_time = telemetryCache.get("last_sync_time");
+    const settled_messages = {
+        bap_client_settled: telemetryCache.get("bap_client_settled"),
+        bap_response_settled: telemetryCache.get("bap_response_settled"),
+        bpp_client_settled: telemetryCache.get("bpp_client_settled"),
+        bpp_request_settled: telemetryCache.get("bpp_request_settled"),
+    }
+    const now = new Date().getTime();
+    const events_count = settled_messages.bap_client_settled.length + 
+        settled_messages.bap_response_settled.length + 
+        settled_messages.bpp_client_settled.length + 
+        settled_messages.bpp_request_settled.length;
+    logger.info(`Telemetry events count - ${events_count}`)
+    // If last sync time is more than syncInterval(minutes) thens sync
+    if (now - last_sync_time > getConfig().app.telemetry.syncInterval * 60 * 1000 || events_count >= getConfig().app.telemetry.batchSize) {
+        logger.info("Pushing telemetry to server")
+        const payload_data = Object.values(settled_messages).flat();
+        try {
+            await axios.post(`${getConfig().app.telemetry.url}`, {
+                data: {
+                    id: v1(),
+                    events: payload_data,
+                }
+            });
+            telemetryCache.set("last_sync_time", now);
+            telemetryCache.set("bap_client_settled", []);
+            telemetryCache.set("bap_response_settled", []);
+            telemetryCache.set("bpp_client_settled", []);
+            telemetryCache.set("bpp_request_settled", []);
+        } catch (error) {
+            logger.error(`Error while pushing telemetry to server -`)
+            logger.error(error)
+        }
+    }
+}


### PR DESCRIPTION
Changes made - 
- Add telemetry event generation for actions during the request/response flow
- Add a telemetry cache so the events are batched together to preserve network bandwidth
- Telemetry can be enabled or disabled based on a config flag for the service
- Telemetry data will be pushed with a OR condition
  - No. of minutes from last synced time is greater than the `syncInterval` in config
  - No. of events in the cache has reached the `batchSize` in config
